### PR TITLE
Implement season

### DIFF
--- a/prisma/migrations/20220918060519_season/migration.sql
+++ b/prisma/migrations/20220918060519_season/migration.sql
@@ -1,0 +1,76 @@
+-- AlterTable
+ALTER TABLE "GameResult" ADD COLUMN     "seasonId" TEXT;
+
+-- AlterTable
+ALTER TABLE "Matching" ADD COLUMN     "seasonId" TEXT;
+
+-- CreateTable
+CREATE TABLE "Season" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "startAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Season_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SeasonRecord" (
+    "id" TEXT NOT NULL,
+    "seasonId" TEXT NOT NULL,
+    "ratingId" TEXT NOT NULL,
+    "mu" DOUBLE PRECISION NOT NULL,
+    "sigma" DOUBLE PRECISION NOT NULL,
+    "rankPoint" DOUBLE PRECISION NOT NULL,
+    "winCount" INTEGER NOT NULL,
+    "loseCount" INTEGER NOT NULL,
+
+    CONSTRAINT "SeasonRecord_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RatingChangedHistory" (
+    "id" TEXT NOT NULL,
+    "ratingId" TEXT NOT NULL,
+    "seasonId" TEXT,
+    "muBefore" DOUBLE PRECISION NOT NULL,
+    "muAfter" DOUBLE PRECISION NOT NULL,
+    "sigmaBefore" DOUBLE PRECISION NOT NULL,
+    "sigmaAfter" DOUBLE PRECISION NOT NULL,
+    "reason" TEXT,
+
+    CONSTRAINT "RatingChangedHistory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Season_guildId_startAt_idx" ON "Season"("guildId", "startAt");
+
+-- CreateIndex
+CREATE INDEX "SeasonRecord_seasonId_rankPoint_idx" ON "SeasonRecord"("seasonId", "rankPoint");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SeasonRecord_ratingId_seasonId_key" ON "SeasonRecord"("ratingId", "seasonId");
+
+-- CreateIndex
+CREATE INDEX "RatingChangedHistory_ratingId_seasonId_idx" ON "RatingChangedHistory"("ratingId", "seasonId");
+
+-- CreateIndex
+CREATE INDEX "RatingChangedHistory_seasonId_idx" ON "RatingChangedHistory"("seasonId");
+
+-- AddForeignKey
+ALTER TABLE "GameResult" ADD CONSTRAINT "GameResult_seasonId_fkey" FOREIGN KEY ("seasonId") REFERENCES "Season"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Matching" ADD CONSTRAINT "Matching_seasonId_fkey" FOREIGN KEY ("seasonId") REFERENCES "Season"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SeasonRecord" ADD CONSTRAINT "SeasonRecord_seasonId_fkey" FOREIGN KEY ("seasonId") REFERENCES "Season"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SeasonRecord" ADD CONSTRAINT "SeasonRecord_ratingId_fkey" FOREIGN KEY ("ratingId") REFERENCES "Rating"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RatingChangedHistory" ADD CONSTRAINT "RatingChangedHistory_ratingId_fkey" FOREIGN KEY ("ratingId") REFERENCES "Rating"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RatingChangedHistory" ADD CONSTRAINT "RatingChangedHistory_seasonId_fkey" FOREIGN KEY ("seasonId") REFERENCES "Season"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20220918061700_add_guild_id_to_room/migration.sql
+++ b/prisma/migrations/20220918061700_add_guild_id_to_room/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `guildId` to the `Room` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Room" ADD COLUMN     "guildId" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,8 +61,10 @@ model Rating {
   loseCount Int      @default(0)
   createdAt DateTime @default(now())
 
-  GameResultRating GameResultRating[]
-  JoinedUser       JoinedUser[]
+  GameResultRating     GameResultRating[]
+  JoinedUser           JoinedUser[]
+  seasonRecords        SeasonRecord[]
+  ratingChangedHistory RatingChangedHistory[]
 
   @@unique([userId, guildId, rule])
 }
@@ -74,6 +76,8 @@ model GameResult {
   beta              Float
   metadata          Json?
   rule              String             @default("SplatZones") // remove default value later
+  seasonId          String?
+  season            Season?            @relation(fields: [seasonId], references: [id])
   createdAt         DateTime           @default(now())
   GameResultRating  GameResultRating[]
 }
@@ -106,7 +110,54 @@ model Matching {
   metadata       Json?
   roomId         String   @unique
   room           Room     @relation(fields: [roomId], references: [id])
+  seasonId       String?
+  season         Season?  @relation(fields: [seasonId], references: [id])
   createdAt      DateTime @default(now())
+}
+
+model Season {
+  id                   String                 @id @default(cuid())
+  name                 String
+  guildId              String
+  startAt              DateTime
+  seasonRecords        SeasonRecord[]
+  matchings            Matching[]
+  gameResults          GameResult[]
+  RatingChangedHistory RatingChangedHistory[]
+
+  @@index([guildId, startAt])
+}
+
+model SeasonRecord {
+  id        String @id @default(cuid())
+  seasonId  String
+  season    Season @relation(fields: [seasonId], references: [id])
+  ratingId  String
+  rating    Rating @relation(fields: [ratingId], references: [id])
+  mu        Float
+  sigma     Float
+  rankPoint Float
+  winCount  Int
+  loseCount Int
+
+  @@unique([ratingId, seasonId])
+  @@index([seasonId, rankPoint])
+}
+
+model RatingChangedHistory {
+  id          String  @id @default(cuid())
+  ratingId    String
+  rating      Rating  @relation(fields: [ratingId], references: [id])
+  seasonId    String?
+  season      Season? @relation(fields: [seasonId], references: [id])
+  muBefore    Float
+  muAfter     Float
+  sigmaBefore Float
+  sigmaAfter  Float
+  reason      String?
+
+  @@index([ratingId, seasonId])
+  @@index([seasonId])
 }
 
 model Session {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model User {
 model Room {
   id               String   @id @default(cuid())
   discordChannelId String
+  guildId          String
   rule             String
   createdAt        DateTime @default(now())
   creatorUserId    String

--- a/repl.ts
+++ b/repl.ts
@@ -10,6 +10,7 @@ import { createMatching } from './src/operations/createMatching'
 import { reportMatching } from './src/operations/reportMatching'
 import { cancelMatching } from './src/operations/cancelMatching'
 import { getCurrentSeason } from './src/models/season'
+import { resetSigmaAllInGuild, resetRating } from './src/operations/resetRating'
 
 // Print the welcome message
 console.log(`
@@ -32,6 +33,8 @@ Object.entries({
   reportMatching,
   cancelMatching,
   getCurrentSeason,
+  resetSigmaAllInGuild,
+  resetRating,
 }).forEach(([k, v]) => {
   repl.context[k] = v
 })

--- a/repl.ts
+++ b/repl.ts
@@ -9,6 +9,7 @@ import { breakRoom } from './src/operations/breakRoom'
 import { createMatching } from './src/operations/createMatching'
 import { reportMatching } from './src/operations/reportMatching'
 import { cancelMatching } from './src/operations/cancelMatching'
+import { getCurrentSeason } from './src/models/season'
 
 // Print the welcome message
 console.log(`
@@ -30,6 +31,7 @@ Object.entries({
   createMatching,
   reportMatching,
   cancelMatching,
+  getCurrentSeason,
 }).forEach(([k, v]) => {
   repl.context[k] = v
 })

--- a/src/models/season.ts
+++ b/src/models/season.ts
@@ -1,0 +1,14 @@
+import { prisma } from '../prismaClient'
+
+export const getCurrentSeason = async (guildId: string) => {
+  const season = await prisma.season.findFirst({
+    where: {
+      guildId,
+      startAt: { lte: new Date() },
+    },
+    orderBy: {
+      startAt: 'desc',
+    },
+  })
+  return season
+}

--- a/src/operations/createRoom.ts
+++ b/src/operations/createRoom.ts
@@ -20,6 +20,7 @@ export const createRoom = async (creatorUserId: string, discordChannelId: string
           discordChannelId,
           creatorUserId: creatorUserId,
           rule,
+          guildId,
         },
       })
     } catch (e) {

--- a/src/operations/resetRating.ts
+++ b/src/operations/resetRating.ts
@@ -1,0 +1,55 @@
+import { prisma } from '../prismaClient'
+import { INITIAL_SIGMA } from './registerUserAndRating'
+import { getCurrentSeason } from '../models/season'
+
+export const resetSigmaAllInGuild = async (guildId: string) => {
+  const season = await getCurrentSeason(guildId)
+  await prisma.$transaction(async (prisma) => {
+    const ratings = await prisma.rating.findMany({ where: { guildId } })
+    await prisma.rating.updateMany({
+      where: { id: { in: ratings.map((r) => r.id) } },
+      data: { sigma: INITIAL_SIGMA },
+    })
+
+    await prisma.ratingChangedHistory.createMany({
+      data: ratings.map((rating) => {
+        return {
+          ratingId: rating.id,
+          muBefore: rating.mu,
+          muAfter: rating.mu,
+          sigmaBefore: rating.sigma,
+          sigmaAfter: INITIAL_SIGMA,
+          seasonId: season?.id,
+          reason: 'RESET_SIGMA_ALL_IN_GUILD',
+        }
+      }),
+    })
+  })
+}
+
+export const resetRating = async (ratingId: string, mu: number) => {
+  const rating = await prisma.rating.findUnique({ where: { id: ratingId } })
+  if (!rating) {
+    return 'RATING_NOT_FOUND'
+  }
+  const season = await getCurrentSeason(rating.guildId)
+
+  await prisma.$transaction(async (prisma) => {
+    await prisma.rating.update({
+      where: { id: rating.id },
+      data: { mu, sigma: INITIAL_SIGMA },
+    })
+
+    await prisma.ratingChangedHistory.create({
+      data: {
+        ratingId: rating.id,
+        muBefore: rating.mu,
+        muAfter: mu,
+        sigmaBefore: rating.sigma,
+        sigmaAfter: INITIAL_SIGMA,
+        seasonId: season?.id,
+        reason: 'RESET_RATING',
+      },
+    })
+  })
+}


### PR DESCRIPTION
スプラ3対応として Season という概念を追加する。(2と3の戦績を混ぜたくないため)

Season は guild (=discordのサーバー) 単位で開催するもので、期間が決まっている。
これはスプラ2のXマッチで月ごとにレートがリセットされランキングが開催されるイメージに近い。

- Season ごとに戦績を記録できる。
  - => Season 単位でのランキングが見れるようになる (データ構造上は)
- rating の sigma をリセットできるようにする。
  - 一旦 Season が新しくなったときに guild 単位でリセットする手動オペレーション